### PR TITLE
add opencv, cv2 to images

### DIFF
--- a/docker/4.0.0/base/Dockerfile.cpu
+++ b/docker/4.0.0/base/Dockerfile.cpu
@@ -2,7 +2,7 @@ FROM ubuntu:16.04
 
 RUN  apt-get update && \
     apt-get -y install build-essential python-dev python3-dev python3-pip curl nginx openssh-server libopencv-dev \
-      libopenblas-dev && \
+      libopenblas-dev libgtk2.0-dev && \
     apt-get clean
 
 RUN cd /tmp && \

--- a/docker/4.0.0/base/Dockerfile.gpu
+++ b/docker/4.0.0/base/Dockerfile.gpu
@@ -1,7 +1,7 @@
 FROM nvidia/cuda:9.0-cudnn7-devel
 
 RUN apt-get update && \
-    apt-get -y install build-essential python-dev python3-dev git wget curl nginx openssh-server && \
+    apt-get -y install build-essential python-dev python3-dev git wget curl nginx openssh-server libgtk2.0-dev && \
     apt-get clean
 
 # install pip

--- a/docker/4.0.0/final/py2/Dockerfile.cpu
+++ b/docker/4.0.0/final/py2/Dockerfile.cpu
@@ -1,6 +1,6 @@
 FROM chainer-base:4.0.0-cpu-py2
 
-RUN pip2 install --no-cache chainer==4.0.0 chainermn==1.2.0 chainercv==0.9.0 matplotlib==2.2.0
+RUN pip2 install --no-cache chainer==4.0.0 chainermn==1.2.0 chainercv==0.9.0 matplotlib==2.2.0 opencv-python==3.4.0.12
 
 # Edit matplotlibrc to use "Agg" backend by default to write plots to PNG files (which some Chainer extensions do).
 # https://matplotlib.org/tutorials/introductory/usage.html#what-is-a-backend

--- a/docker/4.0.0/final/py2/Dockerfile.gpu
+++ b/docker/4.0.0/final/py2/Dockerfile.gpu
@@ -1,6 +1,7 @@
 FROM chainer-base:4.0.0-gpu-py2
 
-RUN pip2 install --no-cache chainer==4.0.0 chainermn==1.2.0 chainercv==0.9.0 matplotlib==2.2.0 cupy==4.0.0
+RUN pip2 install --no-cache chainer==4.0.0 chainermn==1.2.0 chainercv==0.9.0 matplotlib==2.2.0 cupy==4.0.0 \
+                            opencv-python==3.4.0.12
 
 # Edit matplotlibrc to use "Agg" backend by default to write plots to PNG files (which some Chainer extensions do).
 # https://matplotlib.org/tutorials/introductory/usage.html#what-is-a-backend

--- a/docker/4.0.0/final/py3/Dockerfile.cpu
+++ b/docker/4.0.0/final/py3/Dockerfile.cpu
@@ -2,7 +2,7 @@ FROM chainer-base:4.0.0-cpu-py3
 
 RUN rm -f /usr/bin/python && ln -s /usr/bin/python3 /usr/bin/python
 
-RUN pip3 install --no-cache chainer==4.0.0 chainermn==1.2.0 chainercv==0.9.0 matplotlib==2.2.0
+RUN pip3 install --no-cache chainer==4.0.0 chainermn==1.2.0 chainercv==0.9.0 matplotlib==2.2.0 opencv-python==3.4.0.12
 
 # Edit matplotlibrc to use "Agg" backend by default to write plots to PNG files (which some Chainer extensions do).
 # https://matplotlib.org/tutorials/introductory/usage.html#what-is-a-backend

--- a/docker/4.0.0/final/py3/Dockerfile.gpu
+++ b/docker/4.0.0/final/py3/Dockerfile.gpu
@@ -2,7 +2,8 @@ FROM chainer-base:4.0.0-gpu-py3
 
 RUN rm -f /usr/bin/python && ln -s /usr/bin/python3 /usr/bin/python
 
-RUN pip3 install --no-cache chainer==4.0.0 chainermn==1.2.0 chainercv==0.9.0 matplotlib==2.2.0 cupy==4.0.0
+RUN pip3 install --no-cache chainer==4.0.0 chainermn==1.2.0 chainercv==0.9.0 matplotlib==2.2.0 cupy==4.0.0 \
+                            opencv-python==3.4.0.12
 
 # Edit matplotlibrc to use "Agg" backend by default to write plots to PNG files (which some Chainer extensions do).
 # https://matplotlib.org/tutorials/introductory/usage.html#what-is-a-backend


### PR DESCRIPTION
This enables opencv-python, which is faster than Pillow and widely used in ChainerCV.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
