### PR TITLE
disable backprop in default predict function. do not get list for npy…

### DIFF
--- a/src/chainer_framework/serving.py
+++ b/src/chainer_framework/serving.py
@@ -3,12 +3,6 @@ import json
 import numpy as np
 import chainer
 
-# Try to import cupy (for GPU inference)
-try:
-    import cupy as cp
-except ImportError:
-    None
-
 from chainer_framework.serialization import npy, csv
 from container_support.app import ServingEngine
 from container_support.serving import JSON_CONTENT_TYPE, CSV_CONTENT_TYPE, NPY_CONTENT_TYPE, \


### PR DESCRIPTION
This should make ∂efault predict faster, and let output fn return dtype correctly

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
