### PR TITLE
wait for algo-1 to be available when running with mpi

### DIFF
--- a/src/chainer_framework/training.py
+++ b/src/chainer_framework/training.py
@@ -55,13 +55,13 @@ def train(user_module, training_environment):
 
     if use_mpi:
         current_host = training_environment.current_host
-        hosts = training_environment.hosts
+        hosts = list(training_environment.hosts)
         _change_hostname(current_host)
+        _start_ssh_daemon()
         if current_host == _get_master_host_name(hosts):
-            _wait_for_worker_nodes_to_start_sshd([host for host in hosts if host != current_host])
+            _wait_for_worker_nodes_to_start_sshd(hosts)
             _run_mpi_on_all_nodes(training_environment)
         else:
-            _start_ssh_daemon()
             _wait_for_training_to_finish(training_environment)
     else:
         _run_training(training_environment, user_module)

--- a/test/unit/test_training.py
+++ b/test/unit/test_training.py
@@ -154,27 +154,15 @@ def test_distributed_training_dont_save_model_on_worker_nodes(worker_node_distri
 
 def test_distributed_training_from_master_node(master_node_distributed_training_env, user_module):
     with patch('chainer_framework.training._change_hostname') as mock_change_hostname, \
+         patch('chainer_framework.training._start_ssh_daemon') as mock_start_ssh_daemon, \
          patch('chainer_framework.training._wait_for_worker_nodes_to_start_sshd') as mock_wait_for_sshd, \
          patch ('chainer_framework.training._run_mpi_on_all_nodes') as mock_run_mpi_on_all_nodes:
 
         train(user_module, master_node_distributed_training_env)
 
         mock_change_hostname.assert_called_once_with(master_node_distributed_training_env.current_host)
-        mock_wait_for_sshd.assert_called_once_with([host for host in master_node_distributed_training_env.hosts
-                                                    if host != master_node_distributed_training_env.current_host])
-        mock_run_mpi_on_all_nodes.assert_called_once_with(master_node_distributed_training_env)
-
-
-def test_distributed_training_from_master_node(master_node_distributed_training_env, user_module):
-    with patch('chainer_framework.training._change_hostname') as mock_change_hostname, \
-         patch('chainer_framework.training._wait_for_worker_nodes_to_start_sshd') as mock_wait_for_sshd, \
-         patch ('chainer_framework.training._run_mpi_on_all_nodes') as mock_run_mpi_on_all_nodes:
-
-        train(user_module, master_node_distributed_training_env)
-
-        mock_change_hostname.assert_called_once_with(master_node_distributed_training_env.current_host)
-        mock_wait_for_sshd.assert_called_once_with([host for host in master_node_distributed_training_env.hosts
-                                                    if host != master_node_distributed_training_env.current_host])
+        mock_start_ssh_daemon.assert_called_once()
+        mock_wait_for_sshd.assert_called_once_with(master_node_distributed_training_env.hosts)
         mock_run_mpi_on_all_nodes.assert_called_once_with(master_node_distributed_training_env)
 
 


### PR DESCRIPTION
When running MPI on a single node on SageMaker, 'algo-1' isn't always ready, resulting in occasional failures. Now we wait for algo-1, too.

Also removing a duplicated unit test. Whoops.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
