### PR TITLE
Add daemon.json to access gpu for docker-compose with nvidia-docker2

### DIFF
--- a/notebooks/chainer_mnist/daemon.json
+++ b/notebooks/chainer_mnist/daemon.json
@@ -1,0 +1,10 @@
+
+{
+	"default-runtime": "nvidia",
+    "runtimes": {
+        "nvidia": {
+            "path": "/usr/bin/nvidia-container-runtime",
+            "runtimeArgs": []
+        }
+    }
+}


### PR DESCRIPTION
*Issue #, if available:*
I forgot to copy and paste the daemon.json file that configures docker-compose to work with nvidia-docker2. So current mnist local mode notebook cannot access gpu resouces.

*Description of changes:*
Add the daemon.json file.
Test on p2.xlarge, and see num_gpus = 1.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
