### PR TITLE
Fix support for subdirectories in user code

### DIFF
--- a/docker/4.0.0/base/Dockerfile.cpu
+++ b/docker/4.0.0/base/Dockerfile.cpu
@@ -1,7 +1,7 @@
 FROM ubuntu:16.04
 
 RUN  apt-get update && \
-    apt-get -y install build-essential python-dev python3-dev python3-pip curl nginx openssh-server \
+    apt-get -y install build-essential python-dev python3-dev curl nginx openssh-server \
     libopencv-dev python-tk libopenblas-dev libgtk2.0-dev git && \
     apt-get clean
 

--- a/test/integration/local/test_mnist.py
+++ b/test/integration/local/test_mnist.py
@@ -42,7 +42,7 @@ def test_chainer_mnist_single_machine(docker_image, opt_ml, use_gpu):
     script_path = os.path.join(mnist_path, customer_script)
 
     with local_mode.serve(script_path, model_dir=None, image_name=docker_image,
-                          opt_ml=opt_ml, use_gpu=use_gpu):
+                          opt_ml=opt_ml, use_gpu=use_gpu, source_dir=mnist_path):
 
         test_arrays = [np.zeros((100, 784), dtype='float32'),
                        np.zeros((100, 1, 28, 28), dtype='float32'),

--- a/test/integration/sagemaker/test_mnist.py
+++ b/test/integration/sagemaker/test_mnist.py
@@ -22,20 +22,22 @@ from estimator import ChainerTestEstimator
 
 
 def test_chainer_mnist_single_machine(sagemaker_session, ecr_image, instance_type):
-    script_path = 'test/resources/mnist/single_machine_customer_script.py'
-    _test_mnist(sagemaker_session, ecr_image, instance_type, script_path, 1)
+    _test_mnist(sagemaker_session, ecr_image, instance_type, 1)
 
 
 def test_chainer_mnist_distributed(sagemaker_session, ecr_image, instance_type):
-    script_path = 'test/resources/mnist/distributed_customer_script.py'
-    _test_mnist(sagemaker_session, ecr_image, instance_type, script_path, 2)
+    _test_mnist(sagemaker_session, ecr_image, instance_type, 2)
 
 
-def _test_mnist(sagemaker_session, ecr_image, instance_type, script_path, instance_count):
+def _test_mnist(sagemaker_session, ecr_image, instance_type, instance_count):
+    source_dir = 'test/resources/mnist'
+    script = 'single_machine_customer_script.py'
+
     with timeout(minutes=15):
         data_path = 'test/resources/mnist/data'
 
-        chainer = ChainerTestEstimator(entry_point=script_path,
+        chainer = ChainerTestEstimator(entry_point=script,
+                                       source_dir=source_dir,
                                        role='SageMakerRole',
                                        train_instance_count=instance_count,
                                        train_instance_type=instance_type,

--- a/test/integration/sagemaker/test_mnist.py
+++ b/test/integration/sagemaker/test_mnist.py
@@ -22,16 +22,15 @@ from estimator import ChainerTestEstimator
 
 
 def test_chainer_mnist_single_machine(sagemaker_session, ecr_image, instance_type):
-    _test_mnist(sagemaker_session, ecr_image, instance_type, 1)
+    _test_mnist(sagemaker_session, ecr_image, instance_type, 1, 'single_machine_customer_script.py')
 
 
 def test_chainer_mnist_distributed(sagemaker_session, ecr_image, instance_type):
-    _test_mnist(sagemaker_session, ecr_image, instance_type, 2)
+    _test_mnist(sagemaker_session, ecr_image, instance_type, 2, 'distributed_customer_script.py')
 
 
-def _test_mnist(sagemaker_session, ecr_image, instance_type, instance_count):
+def _test_mnist(sagemaker_session, ecr_image, instance_type, instance_count, script):
     source_dir = 'test/resources/mnist'
-    script = 'single_machine_customer_script.py'
 
     with timeout(minutes=15):
         data_path = 'test/resources/mnist/data'

--- a/test/resources/mnist/single_machine_customer_script.py
+++ b/test/resources/mnist/single_machine_customer_script.py
@@ -17,11 +17,12 @@ import os
 
 import chainer
 from chainer import serializers, training
-from chainer.datasets import tuple_dataset
 import chainer.functions as F
 import chainer.links as L
 from chainer.training import extensions
 import numpy as np
+
+from utils.preprocess import preprocess_mnist
 
 
 class MLP(chainer.Chain):
@@ -39,29 +40,7 @@ class MLP(chainer.Chain):
         return self.l3(h2)
 
 
-def _preprocess_mnist(raw, withlabel, ndim, scale, image_dtype, label_dtype, rgb_format):
-    images = raw['x']
-    if ndim == 2:
-        images = images.reshape(-1, 28, 28)
-    elif ndim == 3:
-        images = images.reshape(-1, 1, 28, 28)
-        if rgb_format:
-            images = np.broadcast_to(images,
-                                     (len(images), 3) + images.shape[2:])
-    elif ndim != 1:
-        raise ValueError('invalid ndim for MNIST dataset')
-    images = images.astype(image_dtype)
-    images *= scale / 255.
-
-    if withlabel:
-        labels = raw['y'].astype(label_dtype)
-        return tuple_dataset.TupleDataset(images, labels)
-    else:
-        return images
-
-
 if __name__ == '__main__':
-
     parser = argparse.ArgumentParser()
 
     # Data and model checkpoints directories
@@ -88,8 +67,8 @@ if __name__ == '__main__':
                                 'label_dtype': np.int32,
                                 'rgb_format': False}
 
-    train = _preprocess_mnist(train_file, **preprocess_mnist_options)
-    test = _preprocess_mnist(test_file, **preprocess_mnist_options)
+    train = preprocess_mnist(train_file, **preprocess_mnist_options)
+    test = preprocess_mnist(test_file, **preprocess_mnist_options)
 
     # Set up a neural network to train
     # Classifier reports softmax cross entropy loss and accuracy at every

--- a/test/resources/mnist/utils/preprocess.py
+++ b/test/resources/mnist/utils/preprocess.py
@@ -1,0 +1,21 @@
+from chainer.datasets import tuple_dataset
+import numpy as np
+
+
+def preprocess_mnist(raw, withlabel, ndim, scale, image_dtype, label_dtype, rgb_format):
+    images = raw['x']
+    if ndim == 2:
+        images = images.reshape(-1, 28, 28)
+    elif ndim == 3:
+        images = images.reshape(-1, 1, 28, 28)
+        if rgb_format:
+            images = np.broadcast_to(images, (len(images), 3) + images.shape[2:])
+    elif ndim != 1:
+        raise ValueError('invalid ndim for MNIST dataset')
+    images = images.astype(image_dtype)
+    images *= scale / 255.
+
+    if withlabel:
+        labels = raw['y'].astype(label_dtype)
+        return tuple_dataset.TupleDataset(images, labels)
+    return images


### PR DESCRIPTION
For some reason the version of pip from python3-pip doesn't correctly install code in subdirectories for packages generated by sagemaker-containers. This change removes that install (so we instead use https://bootstrap.pypa.io/get-pip.py).

Modified a local integ test to use code in a subdir to verify this behavior. Local tests pass.