### PR TITLE
Fix broken image build instruction

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -113,10 +113,10 @@ Dockerfile.
 
     # Create the SageMaker Chainer Container Python package.
     cd sagemaker-chainer-container
-    python setup.py sdist
+    python setup.py bdist_wheel
 
     #. Copy your Python package to "final" Dockerfile directory that you are building.
-    cp dist/sagemaker_chainer_container-<package_version>.tar.gz docker/<Chainer_version>/final
+    cp -R dist/sagemaker_chainer_container-<package_version>.tar.gz docker/<Chainer_version>/final/<py_version>
 
 If you want to build "final" Docker images, then use:
 


### PR DESCRIPTION
Change the packaging command to use the wheel format and fix the path where the
package is copied to.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
