### PR TITLE
bump minimum sagemaker-containers version to 2.2.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3.5',
     ],
-    install_requires=['sagemaker-containers >= 2.1.0', 'chainer >= 4.0.0', 'retrying==1.3.3',
+    install_requires=['sagemaker-containers >= 2.2.0', 'chainer >= 4.0.0', 'retrying==1.3.3',
                       'numpy >= 1.14'],
 
     dependency_links=['pip install git+https://github.com/aws/sagemaker-python-sdk-staging'],


### PR DESCRIPTION
There was a breaking change in [SageMaker Containers 2.2.0](https://github.com/aws/sagemaker-containers/blob/master/CHANGELOG.rst#220), which #57 took into account.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.