### PR TITLE
Temporarily freeze sagemaker-containers version to 2.2.5 until we have a proper fix.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,8 @@ setup(
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3.5',
     ],
-    install_requires=['sagemaker-containers >= 2.2.0', 'chainer >= 4.0.0', 'retrying==1.3.3',
+    # Temporarily freeze sagemaker-containers version to 2.2.5 until we have a proper fix
+    install_requires=['sagemaker-containers == 2.2.5', 'chainer >= 4.0.0', 'retrying==1.3.3',
                       'numpy >= 1.14'],
 
     dependency_links=['pip install git+https://github.com/aws/sagemaker-python-sdk-staging'],


### PR DESCRIPTION
Temporarily freeze sagemaker-containers version to 2.2.5 until we have a proper fix.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
