### PR TITLE
update cupy to 5.0 for chainer 5.0

### DIFF
--- a/docker/5.0.0/final/py2/Dockerfile.gpu
+++ b/docker/5.0.0/final/py2/Dockerfile.gpu
@@ -2,7 +2,7 @@ FROM chainer-base:5.0.0-gpu-py2
 
 LABEL com.amazonaws.sagemaker.capabilities.accept-bind-to-port=true
 
-RUN pip2 install --no-cache chainer==5.0.0 chainercv==0.11.0 matplotlib==2.2.0 cupy==4.1.0 \
+RUN pip2 install --no-cache chainer==5.0.0 chainercv==0.11.0 matplotlib==2.2.0 cupy==5.0.0 \
                             opencv-python==3.4.0.12 mpi4py==3.0.0
 
 # Edit matplotlibrc to use "Agg" backend by default to write plots to PNG files (which some Chainer extensions do).

--- a/docker/5.0.0/final/py3/Dockerfile.gpu
+++ b/docker/5.0.0/final/py3/Dockerfile.gpu
@@ -4,7 +4,7 @@ LABEL com.amazonaws.sagemaker.capabilities.accept-bind-to-port=true
 
 RUN rm -f /usr/bin/python && ln -s /usr/bin/python3 /usr/bin/python
 
-RUN pip3 install --no-cache chainer==5.0.0 chainercv==0.11.0 matplotlib==2.2.0 cupy==4.1.0 \
+RUN pip3 install --no-cache chainer==5.0.0 chainercv==0.11.0 matplotlib==2.2.0 cupy==5.0.0 \
                             opencv-python==3.4.0.12 mpi4py==3.0.0
 
 # Edit matplotlibrc to use "Agg" backend by default to write plots to PNG files (which some Chainer extensions do).


### PR DESCRIPTION
cupy 5.0 is required for the GPU images using chainer 5.0

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
