### PR TITLE
Upgrade SageMaker Containers version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,8 +30,8 @@ setup(
         'Programming Language :: Python :: 3.5',
     ],
     # Temporarily freeze sagemaker-containers version to 2.2.5 until we have a proper fix
-    install_requires=['sagemaker-containers == 2.2.5', 'chainer >= 4.0.0', 'retrying==1.3.3',
-                      'numpy >= 1.14'],
+    install_requires=['sagemaker-containers>=2.2.5', 'chainer==5.0.0', 'retrying==1.3.3',
+                      'numpy>=1.14'],
 
     dependency_links=['pip install git+https://github.com/aws/sagemaker-python-sdk-staging'],
     extras_require={

--- a/src/sagemaker_chainer_container/training.py
+++ b/src/sagemaker_chainer_container/training.py
@@ -194,6 +194,8 @@ def _get_mpi_command(env, hyperparameters):
             mpi_command += ' -x {}'.format(v)
 
     for name, value in env.to_env_vars().items():
+        # TODO: figure out why passing additional framework parameters
+        # (new with SageMaker Containers v2.2.6) causes MPI to hang
         if not name == 'SM_FRAMEWORK_PARAMS':
             mpi_command += ' -x {}="{}"'.format(name, value)
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -41,7 +41,7 @@ def pytest_addoption(parser):
     parser.addoption('--instance-type')
     parser.addoption('--docker-base-name', default='chainer')
     parser.addoption('--region', default='us-west-2')
-    parser.addoption('--framework-version', default='4.1.0')
+    parser.addoption('--framework-version', default='5.0.0')
     parser.addoption('--py-version', choices=['2', '3'], default='3')
     parser.addoption('--processor', choices=['gpu', 'cpu'], default='cpu')
     # If not specified, will default to {framework-version}-{processor}-py{py-version}


### PR DESCRIPTION
I realize this isn't much better than #58, but I don't think it's worse, and this will allow us to take advantage of new features in SageMaker Containers. This change is reliant on aws/sagemaker-containers#141 being released to PyPI, but I tested locally by rebuilding the images and all the integ tests (both local and SageMaker) passed.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
