### PR TITLE
Remove additional framework parameters from MPI command

### DIFF
--- a/src/sagemaker_chainer_container/training.py
+++ b/src/sagemaker_chainer_container/training.py
@@ -199,7 +199,7 @@ def _get_mpi_command(env, hyperparameters):
         # (new with SageMaker Containers v2.2.6) causes MPI to hang
         if name == 'SM_TRAINING_ENV':
             env_dict = json.loads(value)
-            del env_dict['additional_framework_parameters']
+            env_dict.pop('additional_framework_parameters', None)
             value = json.dumps(env_dict)
 
         if not name == 'SM_FRAMEWORK_PARAMS':

--- a/src/sagemaker_chainer_container/training.py
+++ b/src/sagemaker_chainer_container/training.py
@@ -12,6 +12,7 @@
 # language governing permissions and limitations under the License.
 from __future__ import absolute_import
 
+import json
 import logging
 import os
 import shlex
@@ -196,6 +197,11 @@ def _get_mpi_command(env, hyperparameters):
     for name, value in env.to_env_vars().items():
         # TODO: figure out why passing additional framework parameters
         # (new with SageMaker Containers v2.2.6) causes MPI to hang
+        if name == 'SM_TRAINING_ENV':
+            env_dict = json.loads(value)
+            del env_dict['additional_framework_parameters']
+            value = json.dumps(env_dict)
+
         if not name == 'SM_FRAMEWORK_PARAMS':
             mpi_command += ' -x {}="{}"'.format(name, value)
 


### PR DESCRIPTION
...not my best idea for a workaround. This is a follow-up to the workaround in the previous commit. The MPI command was failing with Python SDK tests due to the string not being wrapped in quotes when part of the MPI command. This commit is meant as a workaround until a better solution is
found for constructing the MPI command.

Another possibility would be to wrap everything in quotes as it gets passed into the MPI command (escaping any existing quotes as necessary), but I didn't bother since we should just figure out what MPI actually needs and not construct a unnecessarily massive command.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
