### PR TITLE
Freeze pip version to <= 18.1

### DIFF
--- a/docker/base/Dockerfile.cpu
+++ b/docker/base/Dockerfile.cpu
@@ -7,8 +7,8 @@ RUN  apt-get update && \
 
 RUN cd /tmp && \
      curl -O https://bootstrap.pypa.io/get-pip.py && \
-     python2 get-pip.py && \
-     python3 get-pip.py && \
+     python2 get-pip.py 'pip<=18.1' && \
+     python3 get-pip.py 'pip<=18.1' && \
      rm get-pip.py
 
 # https://stackoverflow.com/questions/29274638/opencv-libdc1394-error-failed-to-initialize-libdc1394

--- a/docker/base/Dockerfile.gpu
+++ b/docker/base/Dockerfile.gpu
@@ -7,8 +7,8 @@ RUN apt-get update && \
 # install pip
 RUN cd /tmp && \
      curl -O https://bootstrap.pypa.io/get-pip.py && \
-     python2 get-pip.py && \
-     python3 get-pip.py && \
+     python2 get-pip.py 'pip<=18.1' && \
+     python3 get-pip.py 'pip<=18.1' && \
      rm get-pip.py
 
 # CUDA-aware OpenMPI:

--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,8 @@ setup(
         'Programming Language :: Python :: 3.5',
     ],
     # Temporarily freeze sagemaker-containers version to 2.2.5 until we have a proper fix
+    # freeze numpy version because of the python2 bug
+    # in 16.0: https://github.com/numpy/numpy/pull/12754
     install_requires=['sagemaker-containers>=2.2.5', 'chainer==5.0.0', 'retrying==1.3.3',
                       'numpy>=1.14,<=15.4'],
 

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
     # freeze numpy version because of the python2 bug
     # in 16.0: https://github.com/numpy/numpy/pull/12754
     install_requires=['sagemaker-containers>=2.2.5', 'chainer==5.0.0', 'retrying==1.3.3',
-                      'numpy>=1.14,<=15.4'],
+                      'numpy>=1.14,<=1.15.4'],
 
     dependency_links=['pip install git+https://github.com/aws/sagemaker-python-sdk-staging'],
     extras_require={

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(
     ],
     # Temporarily freeze sagemaker-containers version to 2.2.5 until we have a proper fix
     install_requires=['sagemaker-containers>=2.2.5', 'chainer==5.0.0', 'retrying==1.3.3',
-                      'numpy>=1.14'],
+                      'numpy>=1.14,<=15.4'],
 
     dependency_links=['pip install git+https://github.com/aws/sagemaker-python-sdk-staging'],
     extras_require={


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
pip 19.0 breaks the container build. Freeze version to <= 18.1
Error:
Traceback (most recent call last):
File "/usr/local/lib/python2.7/dist-packages/pip/_internal/cli/base_command.py", line 176, in main
status = self.run(options, args)
File "/usr/local/lib/python2.7/dist-packages/pip/_internal/commands/install.py", line 346, in run
session=session, autobuilding=True
File "/usr/local/lib/python2.7/dist-packages/pip/_internal/wheel.py", line 848, in build
assert building_is_possible
AssertionError

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
