### PR TITLE
Read framework version from Python SDK for integ test default

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -21,6 +21,7 @@ import tempfile
 import boto3
 import pytest
 from sagemaker import Session
+from sagemaker.chainer import Chainer
 
 from test.utils import local_mode
 
@@ -41,7 +42,7 @@ def pytest_addoption(parser):
     parser.addoption('--instance-type')
     parser.addoption('--docker-base-name', default='chainer')
     parser.addoption('--region', default='us-west-2')
-    parser.addoption('--framework-version', default='5.0.0')
+    parser.addoption('--framework-version', default=Chainer.LATEST_VERSION)
     parser.addoption('--py-version', choices=['2', '3'], default='3')
     parser.addoption('--processor', choices=['gpu', 'cpu'], default='cpu')
     # If not specified, will default to {framework-version}-{processor}-py{py-version}


### PR DESCRIPTION
following https://github.com/aws/sagemaker-mxnet-container/pull/67 and https://github.com/aws/sagemaker-tensorflow-container/pull/166

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
