### PR TITLE
Freeze PyYAML version to avoid conflict with Docker Compose

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,6 +40,6 @@ setup(
         'test': [
             'tox', 'flake8', 'coverage', 'flake8-import-order', 'pytest', 'pytest-cov',
             'pytest-xdist', 'mock', 'Flask', 'boto3>=1.4.8', 'docker-compose',
-            'nvidia-docker-compose', 'sagemaker>=1.3.0', 'PyYAML'
+            'nvidia-docker-compose', 'sagemaker>=1.3.0', 'PyYAML==3.10'
         ]
     })


### PR DESCRIPTION
*Description of changes:*
Fix for the following exception:

> ContextualVersionConflict: (PyYAML 5.1 (/usr/lib64/python2.7/dist-packages), Requirement.parse('PyYAML<4,>=3.10'), set(['docker-compose']))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
