### PR TITLE
Upgrade numpy to 1.16.2 for compatibility to ChainerCV

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
     # freeze numpy version because of the python2 bug
     # in 16.0: https://github.com/numpy/numpy/pull/12754
     install_requires=['sagemaker-containers>=2.2.5', 'chainer==5.0.0', 'retrying==1.3.3',
-                      'numpy>=1.14,<=1.15.4'],
+                      'numpy==1.16.2'],
 
     dependency_links=['pip install git+https://github.com/aws/sagemaker-python-sdk-staging'],
     extras_require={


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Run `import chainercv` in container will result to numpy size mismatch problem. It turns out numpy 1.15.4 is not compatible with chainercv 0.12 in chainer 5.0.0. This PR updates numpy to 1.16.2 to fix this and tests run well for `import chainercv`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
