### PR TITLE
Fix broken line of buildspec

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -21,7 +21,7 @@ phases:
       - ACCOUNT=$(aws sts get-caller-identity --query 'Account' --output text)
       - PREPROD_IMAGE="$ACCOUNT.dkr.ecr.$AWS_DEFAULT_REGION.amazonaws.com/$ECR_REPO"
       - PR_NUM=$(echo $CODEBUILD_SOURCE_VERSION | grep -o '[0-9]\+')
-      - echo "Pull request number: $PR_NUM. No value means this build is not from pull request."
+      - echo 'Pull request number:' $PR_NUM '. No value means this build is not from pull request.'
 
   build:
     commands:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Fix the broken line of buildspec. Current error is:

YAML_FILE_ERROR: Expected Commands[4] to be of string type: found subkeys instead at line 23, value of the key tag on line 22 might be empty
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
