### PR TITLE
pin pluggy version to workaround configparser error

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ setup(
     dependency_links=['pip install git+https://github.com/aws/sagemaker-python-sdk-staging'],
     extras_require={
         'test': [
-            'tox', 'flake8', 'coverage', 'flake8-import-order', 'pytest', 'pytest-cov',
+            'tox', 'pluggy==0.11', 'flake8', 'coverage', 'flake8-import-order', 'pytest', 'pytest-cov',
             'pytest-xdist', 'mock', 'Flask', 'boto3>=1.4.8', 'docker-compose',
             'nvidia-docker-compose', 'sagemaker>=1.18.14', 'PyYAML==3.10'
         ]


### PR DESCRIPTION
running unit tests through pytest fails due to the following error starting on 5/27:

```
pytest test/unit 
Traceback (most recent call last): 
File "/usr/bin/pytest", line 7, in <module> 
from pytest import main 
File "/usr/lib/python2.7/dist-packages/pytest.py", line 7, in <module> 
from _pytest.assertion import register_assert_rewrite 
File "/usr/lib/python2.7/dist-packages/_pytest/assertion/__init__.py", line 12, in <module> 
from _pytest.assertion import rewrite 
File "/usr/lib/python2.7/dist-packages/_pytest/assertion/rewrite.py", line 23, in <module> 
from _pytest.assertion import util 
File "/usr/lib/python2.7/dist-packages/_pytest/assertion/util.py", line 10, in <module> 
import _pytest._code 
File "/usr/lib/python2.7/dist-packages/_pytest/_code/__init__.py", line 6, in <module> 
from .code import Code # noqa 
File "/usr/lib/python2.7/dist-packages/_pytest/_code/code.py", line 14, in <module> 
import pluggy 
File "/usr/lib/python2.7/dist-packages/pluggy/__init__.py", line 16, in <module> 
from .manager import PluginManager, PluginValidationError 
File "/usr/lib/python2.7/dist-packages/pluggy/manager.py", line 6, in <module> 
import importlib_metadata 
File "/usr/lib/python2.7/dist-packages/importlib_metadata/__init__.py", line 14, in <module> 
from ._compat import ( 
File "/usr/lib/python2.7/dist-packages/importlib_metadata/_compat.py", line 17, in <module> 
from backports.configparser import ConfigParser 
ImportError: No module named configparser 
```
We take dependency on tox, which takes dependency on pluggy.

If I do a pip install --upgrade pluggy==0.11, then the problem below seems to disappear, however I can't seem to figure out what pluggy changed to cause this error, however the timelines align, as a new version of pluggy was released on 5/27. 

Looking at the commit history there doesn't seem to be anything that messes around with pytest or configparser, but it looks like the fix for now is to pin pluggy at 0.11, as tox doesn't pin it. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
