### PR TITLE
pin pytest to 4.5.0 to work around configparser error

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -50,8 +50,8 @@ setup(
     dependency_links=['pip install git+https://github.com/aws/sagemaker-python-sdk-staging'],
     extras_require={
         'test': [
-            'tox', 'pluggy==0.11', 'flake8', 'coverage', 'flake8-import-order', 'pytest', 'pytest-cov',
+            'tox', 'flake8', 'coverage', 'flake8-import-order', 'pytest==4.5.0', 'pytest-cov',
             'pytest-xdist', 'mock', 'Flask', 'boto3>=1.4.8', 'docker-compose',
-            'nvidia-docker-compose', 'sagemaker>=1.18.14', 'PyYAML==3.10'
+            'nvidia-docker-compose', 'sagemaker>=1.18.14', 'PyYAML==3.10', 'pluggy==0.11'
         ]
     })


### PR DESCRIPTION
Similar: https://github.com/aws/sagemaker-chainer-container/pull/84

Running the pytest command is failing due to the following error:
```
pytest test/unit 
Traceback (most recent call last): 
File "/usr/bin/pytest", line 7, in <module> 
from pytest import main 
File "/usr/lib/python2.7/dist-packages/pytest.py", line 7, in <module> 
from _pytest.assertion import register_assert_rewrite 
File "/usr/lib/python2.7/dist-packages/_pytest/assertion/__init__.py", line 12, in <module> 
from _pytest.assertion import rewrite 
File "/usr/lib/python2.7/dist-packages/_pytest/assertion/rewrite.py", line 23, in <module> 
from _pytest.assertion import util 
File "/usr/lib/python2.7/dist-packages/_pytest/assertion/util.py", line 10, in <module> 
import _pytest._code 
File "/usr/lib/python2.7/dist-packages/_pytest/_code/__init__.py", line 6, in <module> 
from .code import Code # noqa 
File "/usr/lib/python2.7/dist-packages/_pytest/_code/code.py", line 14, in <module> 
import pluggy 
File "/usr/lib/python2.7/dist-packages/pluggy/__init__.py", line 16, in <module> 
from .manager import PluginManager, PluginValidationError 
File "/usr/lib/python2.7/dist-packages/pluggy/manager.py", line 6, in <module> 
import importlib_metadata 
File "/usr/lib/python2.7/dist-packages/importlib_metadata/__init__.py", line 14, in <module> 
from ._compat import ( 
File "/usr/lib/python2.7/dist-packages/importlib_metadata/_compat.py", line 17, in <module> 
from backports.configparser import ConfigParser 
ImportError: No module named configparser 
```

This happens as importlib_metadata package retrieves configparser from backports.configparser, however it seems that backports.configparser is only available in python 3.5+: https://gitlab.com/python-devs/importlib_metadata/issues/66

Doing a pip install --upgrade configparser or on backports, doesn't solve this issue.

The reason this error is occurring again is that pytest released 4.6.0, which takes dependency on pluggy 0.12, which takes dependency on importlib_metadata 0.12+, where this problem occurs.

The quickest workaround right now is to pin pytest, however the best solution in my opinion it to utilize tox for pinning these versions or just dropping python 2.7 testing.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
