### PR TITLE
fix: update openmpi to 4.0.0

### DIFF
--- a/docker/base/Dockerfile.cpu
+++ b/docker/base/Dockerfile.cpu
@@ -19,10 +19,10 @@ RUN cd /tmp && \
 RUN ln -s /dev/null /dev/raw1394
 
 RUN cd /tmp && \
-        wget "https://www.open-mpi.org/software/ompi/v2.1/downloads/openmpi-2.1.2.tar.gz" && \
-        tar xzf openmpi-2.1.2.tar.gz && \
-        cd openmpi-2.1.2  && \
-        ./configure && make all && make install && ldconfig && rm -rf /tmp/*
+        wget https://www.open-mpi.org/software/ompi/v4.0/downloads/openmpi-4.0.0.tar.gz && \
+        tar xzf openmpi-4.0.0.tar.gz && \
+        cd openmpi-4.0.0 && \
+        ./configure --enable-orterun-prefix-by-default && make all && make install && ldconfig && rm -rf /tmp/*
 
 RUN echo "hwloc_base_binding_policy = none" >> /usr/local/etc/openmpi-mca-params.conf && \
     echo "rmaps_base_mapping_policy = slot" >> /usr/local/etc/openmpi-mca-params.conf

--- a/docker/base/Dockerfile.cpu
+++ b/docker/base/Dockerfile.cpu
@@ -22,7 +22,7 @@ RUN cd /tmp && \
         wget https://www.open-mpi.org/software/ompi/v4.0/downloads/openmpi-4.0.0.tar.gz && \
         tar xzf openmpi-4.0.0.tar.gz && \
         cd openmpi-4.0.0 && \
-        ./configure --enable-orterun-prefix-by-default && make all && make install && ldconfig && rm -rf /tmp/*
+        ./configure && make all && make install && ldconfig && rm -rf /tmp/*
 
 RUN echo "hwloc_base_binding_policy = none" >> /usr/local/etc/openmpi-mca-params.conf && \
     echo "rmaps_base_mapping_policy = slot" >> /usr/local/etc/openmpi-mca-params.conf

--- a/docker/base/Dockerfile.gpu
+++ b/docker/base/Dockerfile.gpu
@@ -17,10 +17,10 @@ RUN cd /tmp && \
 # CUDA-aware OpenMPI:
 # 2.1.2 is recommended by Chainer.
 RUN cd /tmp && \
-        wget "https://www.open-mpi.org/software/ompi/v2.1/downloads/openmpi-2.1.2.tar.gz" && \
-        tar xzf openmpi-2.1.2.tar.gz && \
-        cd openmpi-2.1.2  && \
-        ./configure --with-cuda && make all && make -j"$(nproc)" install && ldconfig && rm -rf /tmp/*
+        wget https://www.open-mpi.org/software/ompi/v4.0/downloads/openmpi-4.0.0.tar.gz && \
+        tar xzf openmpi-4.0.0.tar.gz && \
+        cd openmpi-4.0.0 && \
+        ./configure && make all && make install && ldconfig && rm -rf /tmp/*
 
 RUN echo "hwloc_base_binding_policy = none" >> /usr/local/etc/openmpi-mca-params.conf && \
     echo "rmaps_base_mapping_policy = slot" >> /usr/local/etc/openmpi-mca-params.conf


### PR DESCRIPTION
*Issue #, if available:*
- older versions of openmpi have inconsistent hostname resolution resulting in flaky behaviour. see https://github.com/horovod/horovod/issues/951 and https://users.open-mpi.narkive.com/O8OcyQEf/ompi-users-ssh-could-not-resolve-hostname-xxxx-name-or-service-not-known-v1-8

*Description of changes:*
- update openmpi version to 4.0.0

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
