### PR TITLE
fix: update minimum git tag to 1.0.1 in buildspec-release.yml

### DIFF
--- a/buildspec-release.yml
+++ b/buildspec-release.yml
@@ -22,7 +22,7 @@ phases:
   build:
     commands:
       # prepare the release
-      - git-release --prepare --min-version 1.0
+      - git-release --prepare --min-version 1.0.1
 
       # install
       - pip3 install -U -e .


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The release build is failing with unexpected tag error. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
