### PR TITLE
change: use sagemaker_session in deploy test

### DIFF
--- a/test/integration/sagemaker/test_mnist.py
+++ b/test/integration/sagemaker/test_mnist.py
@@ -81,6 +81,7 @@ def _test_mnist_deploy(sagemaker_session, instance_type):
             model_data=model_data,
             role='SageMakerRole',
             entry_point=script_path,
+            sagemaker_session=sagemaker_session,
         )
         predictor = chainer.deploy(initial_instance_count=1, instance_type=instance_type)
 


### PR DESCRIPTION
*Description of changes:*
By not using the `sagemaker_session` fixture, the tests would fail if the environment does not have an AWS region configured.

*Testing done:*

```bash
# make sure no region is set
$ python
[...]
Type "help", "copyright", "credits" or "license" for more information.
>>> import sagemaker
>>> sagemaker.session.Session()
Traceback (most recent call last):
  [...]
    "Must setup local AWS configuration with a region supported by SageMaker."
ValueError: Must setup local AWS configuration with a region supported by SageMaker.
>>> 

# run test
$ pytest test/integration/sagemaker/test_mnist.py::test_chainer_deploy --instance-type ml.m4.xlarge
========================== test session starts ==========================
platform darwin -- Python 3.6.8, pytest-4.4.1, py-1.8.0, pluggy-0.12.0 -- [...]
cachedir: .pytest_cache                           
rootdir: ~/sagemaker-chainer-container, inifile: setup.cfg
plugins: cov-2.6.1, forked-1.0.2, rerunfailures-7.0, xdist-1.29.0
collected 1 item                                                                                                                                                                                                                                                                                                                                                         

test/integration/sagemaker/test_mnist.py::test_chainer_deploy PASSED      [100%]
                                                
========================== 1 passed in 504.09 seconds ==========================
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
