### PR TITLE
change: enable IGNORE_COVERAGE when invoking coverage with tox

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -48,7 +48,7 @@ passenv =
 commands =
     pip install -U sagemaker-containers
     coverage run --source sagemaker_chainer_container -m py.test test/unit {posargs}
-    coverage report
+    {env:IGNORE_COVERAGE:} coverage report
 deps =
     coverage
     pytest


### PR DESCRIPTION
*Description of changes:*
Our release builds our failing because tox is trying to generate a coverage report despite the `IGNORE_COVERAGE` environment variable. I tested locally before and after making the change to verify this works.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
